### PR TITLE
Make sure to print go panic context

### DIFF
--- a/harness_wrappers/harness_fuzz.go
+++ b/harness_wrappers/harness_fuzz.go
@@ -22,7 +22,10 @@ func LLVMFuzzerTestOneInput(data *C.char, size C.size_t) C.int {
 }
 
 func catchPanics() {
-	if recover() != nil {
+	if r := recover(); r != nil {
+		// print panic information
+		fmt.Printf("Go panic: %v\n", r)
+		debug.PrintStack()
 		syscall.Kill(os.Getpid(), syscall.SIGABRT)
 	}
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -29,7 +29,6 @@ use libafl_targets::{
     CmpLogObserver, COUNTERS_MAPS,
 };
 use mimalloc::MiMalloc;
-use std::process::Command;
 use std::{
     env, fs,
     fs::read_dir,
@@ -37,6 +36,7 @@ use std::{
     process::Stdio,
     time::Duration,
 };
+use std::{panic, process::Command};
 
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
@@ -137,7 +137,6 @@ fn run(input: PathBuf) {
         let inp =
             std::fs::read(f).unwrap_or_else(|_| panic!("Unable to read file {}", &f.display()));
         if inp.len() > 1 {
-            println!("INPUT: {inp:?}");
             unsafe {
                 libfuzzer_test_one_input(&inp);
             }


### PR DESCRIPTION
Make sure we print panic information and stack trace when the Go code panics. Beforehand, running a crashing input would only print `Aborted`. Now we print the full context, e.g.:

```bash
Go panic: type ReferendumInfo<BlockNumber, Hash, BalanceOf> index out of range [226] with length 2
goroutine 17 [running, locked to thread]:
runtime/debug.Stack()
        /usr/local/go/src/runtime/debug/stack.go:26 +0x9b
runtime/debug.PrintStack()
        /usr/local/go/src/runtime/debug/stack.go:18 +0x2f
main.catchPanics()
        /home/h0ps/fuzzing/scale.go/fuzz/harness_fuzz.go:28 +0xa5
panic({0x56478a6e4e20?, 0xc000478740?})
        /usr/local/go/src/runtime/panic.go:792 +0x132
github.com/itering/scale.go/types.(*Enum).Process(0xc0004b2690)
        /home/h0ps/go/pkg/mod/github.com/itering/scale.go@v1.10.4/types/Enum.go:55 +0xd9f
reflect.Value.call({0x56478a703b60?, 0xc0004b2690?, 0x56478a703b60?}, {0x56478a12c4b4, 0x4}, {0x0, 0x0, 0x0?})
        /usr/local/go/src/reflect/value.go:584 +0x1ef1
reflect.Value.Call({0x56478a703b60?, 0xc0004b2690?, 0x0?}, {0x0, 0x0, 0x0})
        /usr/local/go/src/reflect/value.go:368 +0x18e
github.com/itering/scale.go/types.(*ScaleDecoder).ProcessAndUpdateData(0xc00002fcf0, {0x56478a136ab6, 0x2c})
        /home/h0ps/go/pkg/mod/github.com/itering/scale.go@v1.10.4/types/base.go:177 +0x653
main.harness({0xc00038e580, 0x35, 0x35})
        /home/h0ps/fuzzing/scale.go/fuzz/harness.go:75 +0x23b
main.LLVMFuzzerTestOneInput(0x2f726080240, 0x56478a4dfc01?)
        /h
```