### PR TITLE
use full path for coverage

### DIFF
--- a/harnesses/README.md
+++ b/harnesses/README.md
@@ -25,16 +25,16 @@ HARNESS=harnesses/caddy cargo run -r -- fuzz -o ./harnesses/caddy
 **Get coverage**
 ```bash
 # get coverage if fuzzer output is in golibafl/output
-cargo run -r -- cov -o ./output -f ./harnesses/caddy
+cargo run -r -- cov -o ./output/queue -f ./harnesses/caddy
 
 # get coverage if fuzzer output is in golibafl/harnesses/caddy
-cargo run -r -- cov -o ./harnesses/caddy -f ./harnesses/caddy
+cargo run -r -- cov -o ./harnesses/caddy/queue -f ./harnesses/caddy
 ```
 
 You can filter for `caddy` and harness specific coverage by providing the package names as coverage filter (`-c`):
 
 ```bash
-cargo run -r -- cov -o ./output -f ./harnesses/caddy -c fuzz,caddy
+cargo run -r -- cov -o ./output/queue -f ./harnesses/caddy -c fuzz,caddy
 
-cargo run -r -- cov -o ./harnesses/caddy -f ./harnesses/caddy -c fuzz,caddy
+cargo run -r -- cov -o ./harnesses/caddy/queue -f ./harnesses/caddy -c fuzz,caddy
 ```

--- a/src/main.rs
+++ b/src/main.rs
@@ -341,7 +341,7 @@ fn cov(output_dir: &Path, harness_dir: &Path, coverage_filter: Option<String>) {
         .to_str()
         .expect("Harness dir not valid unicode");
 
-    test_code = test_code.replace("REPLACE_ME", &format!("{}/queue", output_dir));
+    test_code = test_code.replace("REPLACE_ME", output_dir);
 
     fs::write(format!("{}/harness_test.go", harness_dir), test_code)
         .expect("Failed to write coverage go file");


### PR DESCRIPTION
Assuming ``output/queue`` is a bit problematic when integrating other fuzzers's output.